### PR TITLE
Ensured all values passed to unquote() are quoted to begin with.

### DIFF
--- a/sass/gridle/_functions.scss
+++ b/sass/gridle/_functions.scss
@@ -80,10 +80,10 @@
 ) {
 	// check if has a state named like this
 	@if (type-of($stateMap-or-stateName) == string
-		and  map-has-key($_gridle_states, unquote($stateMap-or-stateName)))
+		and  map-has-key($_gridle_states, unquote("#{$stateMap-or-stateName}")))
 	{
-		@return map-get($_gridle_states, unquote($stateMap-or-stateName));
-	} 
+		@return map-get($_gridle_states, unquote("#{$stateMap-or-stateName}"));
+	}
 
 	// a map is passed, so it's a state himself
 	@if $stateMap-or-stateName
@@ -112,7 +112,7 @@
 @function _gridle_has_state(
 	$stateName
 ) {
-	@if map-has-key($_gridle_states, unquote($stateName)) {
+	@if map-has-key($_gridle_states, unquote("#{$stateName}")) {
 		@return true;
 	} @else {
 		@return false;
@@ -137,9 +137,9 @@
 
 	// check ig state and if has the variable :
 	@if $state
-	      and map-has-key($state,unquote($var))
+		  and map-has-key($state,unquote("#{$var}"))
 	{
-		@return map-get($state,unquote($var));
+		@return map-get($state,unquote("#{$var}"));
 	}
 
 	// nothing getted :
@@ -166,9 +166,9 @@
 
 	// extend default state with given state :
 	$props : map-merge($_gridle-settings, $state);
-	
-	@if map-has-key($props, unquote($varName)) {
-		@return map-get($state, unquote($varName));
+
+	@if map-has-key($props, unquote("#{$varName}")) {
+		@return map-get($state, unquote("#{$varName}"));
 	}
 	
 	// nothing finded :
@@ -193,13 +193,13 @@
 
 	// check ig state and if has the variable :
 	@if $state
-	      and map-has-key($state,unquote($var))
+		  and map-has-key($state,unquote("#{$var}"))
 	{
 		// set new value in state :
-		$state : map-set($state, unquote($var), $newValue);
+		$state : map-set($state, unquote("#{$var}"), $newValue);
 
 		// set states :
-		$_gridle_states : map-set($_gridle_states, unquote($stateName), $state);
+		$_gridle_states : map-set($_gridle_states, unquote("#{$stateName}"), $state);
 
 		// return new state :
 		@return $state;
@@ -250,7 +250,7 @@
 	$sel : ".";
 
 	// delete default :
-	@if unquote($state) == default {
+	@if unquote("#{$state}") == default {
 		$state : null;
 	}
 	

--- a/sass/gridle/_generate-mixins.scss
+++ b/sass/gridle/_generate-mixins.scss
@@ -268,7 +268,7 @@
 			} @elseif type-of($value) == bool {
 				$gridle-settings-states : "#{$gridle-settings-states} \"#{$varName}\" : #{$value},";
 			} @else {
-				$gridle-settings-states : "#{$gridle-settings-states} \"#{$varName}\" : \"#{$value}\",";		
+				$gridle-settings-states : "#{$gridle-settings-states} \"#{$varName}\" : \"#{$value}\",";
 			}
 		}
 
@@ -381,7 +381,7 @@ $_gridle_generateOnlyOnce : true; // keep track of generate once classes
 		@if $what == null or index($what, container) or index($what, default)
 		{
 			$container-selector : ();
-			$container-selector : append( $container-selector, unquote(_gridle_classname($gridle-container-name-pattern)), comma);
+			$container-selector : append( $container-selector, unquote("#{_gridle_classname($gridle-container-name-pattern)}"), comma);
 			#{$container-selector} {
 				@include gridle_container();
 			}
@@ -479,19 +479,19 @@ $_gridle_generateOnlyOnce : true; // keep track of generate once classes
 		 	
 				// add selector :
 				@if $what == null or index($what, grid) or index($what, default) {
-					$grid-common-selector : append( $grid-common-selector, unquote(_gridle_classname($gridle-grid-name-pattern, $media, $columnName)), comma );
+					$grid-common-selector : append( $grid-common-selector, unquote("#{_gridle_classname($gridle-grid-name-pattern, $media, $columnName)}"), comma );
 				}
 				@if $generate-push-classes and ($what == null or index($what, push) or index($what, default)) {
-					$push-common-selector : append( $push-common-selector, unquote(_gridle_classname($gridle-push-name-pattern, $media, $columnName)), comma );
+					$push-common-selector : append( $push-common-selector, unquote("#{_gridle_classname($gridle-push-name-pattern, $media, $columnName)}"), comma );
 				}
 				@if $generate-pull-classes and ($what == null or index($what, pull) or index($what, default)) {
-					$pull-common-selector : append( $pull-common-selector, unquote(_gridle_classname($gridle-pull-name-pattern, $media, $columnName)), comma );
+					$pull-common-selector : append( $pull-common-selector, unquote("#{_gridle_classname($gridle-pull-name-pattern, $media, $columnName)}"), comma );
 				}
 				@if $generate-prefix-classes and ($what == null or index($what, prefix) or index($what, default)) {
-					$prefix-common-selector : append( $prefix-common-selector, unquote(_gridle_classname($gridle-prefix-name-pattern, $media, $columnName)), comma );
+					$prefix-common-selector : append( $prefix-common-selector, unquote("#{_gridle_classname($gridle-prefix-name-pattern, $media, $columnName)}"), comma );
 				}
 				@if $generate-suffix-classes and ($what == null or index($what, suffix) or index($what, default)) {
-					$suffix-common-selector : append( $suffix-common-selector, unquote(_gridle_classname($gridle-suffix-name-pattern, $media, $columnName)), comma );
+					$suffix-common-selector : append( $suffix-common-selector, unquote("#{_gridle_classname($gridle-suffix-name-pattern, $media, $columnName)}"), comma );
 				}
 			}
 		}

--- a/sass/gridle/_mixins.scss
+++ b/sass/gridle/_mixins.scss
@@ -13,7 +13,7 @@
 	// loop on each settings
 	@each $settingName, $settingValue in $settings
 	{
-		$sn : unquote($settingName);
+		$sn : unquote("#{$settingName}");
 		$sv : $settingValue;
 
 		// check if setting name is a state :


### PR DESCRIPTION
This at least stops all of the `DEPRECATION WARNING` messages as mentioned in #36, and it doesn't appear to have stopped working! :shipit: 