### PR TITLE
fixed missing colon in documentation

### DIFF
--- a/doc/02.add-states.md
+++ b/doc/02.add-states.md
@@ -18,7 +18,7 @@ To register a state, Gridle provides a simple and unique mixin:
 */
 @include gridle_register_state( mobile , (
 	max-width : 400px
-) ):
+) );
 @include gridle_register_state( tablet, (
 	min-width : 401px,
 	max-width : 767px,


### PR DESCRIPTION
super tiny typo I noticed while browsing the docs :). 