### PR TITLE
Changed comments style to remove them from CSS output

### DIFF
--- a/sass/grid-bootstrap.scss
+++ b/sass/grid-bootstrap.scss
@@ -12,15 +12,15 @@
 // register states :
 @include gridle_register_default_mobile_first_states();
 
-/*
- * Optional :
- * Change generation class names pattern (for example to match bootstrap naming conventions or generate with your own names) :
- * Check documentation (http://gridle.org/documentation#name-pattern) for full list
- *
- * %- 		= separator sign (configurable by $gridle-class-separator) (no need to add separators if you doesn't want them)
- * %state 	= the state name (mobile, ipad, etc...)
- * %count  	= the column count (1, 2, 3, 4, etc...)
- */
+////
+// Optional :
+// Change generation class names pattern (for example to match bootstrap naming conventions or generate with your own names) :
+// Check documentation (http://gridle.org/documentation#name-pattern) for full list
+//
+// %- 		= separator sign (configurable by $gridle-class-separator) (no need to add separators if you doesn't want them)
+// %state 	= the state name (mobile, ipad, etc...)
+// %count  	= the column count (1, 2, 3, 4, etc...)
+////
 $gridle-grid-name-pattern : ('col','%-','%state','%-','%count');
 $gridle-parent-name-pattern : ('row','%-','%state');
 $gridle-prefix-name-pattern : ('col','%-','%state','%-','offset','%-','%count');
@@ -30,9 +30,9 @@ $gridle-show-name-pattern : ('visible','%-','%state');
 $gridle-hide-name-pattern : ('hidden','%-','%state');
 
 
-/**
- * Mobile first approach :
- */
+////
+// Mobile first approach :
+////
 [class*="col-"] {
 	width:100%; // 100% by default
 }

--- a/sass/gridle/_functions.scss
+++ b/sass/gridle/_functions.scss
@@ -4,15 +4,15 @@
 // |------------------------------------------------------
 // |------------------------------------------------------
 
-/**
- * Str replace
- *
- * @param {string}  $string    String that you want to replace
- * @param {string}  $substr    String that is to be replaced by `$newsubstr`
- * @param {string}  $newsubstr String that replaces `$substr`
- * @param {number*} $all       Flag for replaceing all (1+) or not (0)
- * @return {string}
- */
+////
+// Str replace
+//
+// @param {string}  $string    String that you want to replace
+// @param {string}  $substr    String that is to be replaced by `$newsubstr`
+// @param {string}  $newsubstr String that replaces `$substr`
+// @param {number*} $all       Flag for replaceing all (1+) or not (0)
+// @return {string}
+////
 @function str-replace($string, $substr, $newsubstr, $all: 0) {
 	$position-found: str-index($string, $substr);
 	$processed: ();
@@ -40,27 +40,27 @@
 	@return $string;
 }
 
-/**
- * Map set
- *
- * @param 	Map 	$map 		The map to use
- * @param 	String 	$key 		The key to update
- * @param 	Mixed 	$value 		The new value
- * @return 	Map 			The new map
- */
+////
+// Map set
+//
+// @param 	Map 	$map 		The map to use
+// @param 	String 	$key 		The key to update
+// @param 	Mixed 	$value 		The new value
+// @return 	Map 			The new map
+////
 @function map-set($map, $key, $value) {
 	$new: ($key: $value);
 	@return map-merge($map, $new);
 }
 
 
-/**
- * Get the column width in percent for the global or a specific context
- *
- * @param 	int 		$columns 					The number of columns to calculate
- * @param 	int 		$context : $gridle-columns-count 	 	The context to use
- * @return 	percentage 							The width in percent
- */
+////
+// Get the column width in percent for the global or a specific context
+//
+// @param 	int 		$columns 					The number of columns to calculate
+// @param 	int 		$context : $gridle-columns-count 	 	The context to use
+// @return 	percentage 							The width in percent
+////
 @function gridle_get_column_width(
 	$columns : 1,
 	$stateMap-or-stateName : null
@@ -69,12 +69,12 @@
 }
 
 
-/**
- *  Get a state map
- *
- * @param 	string 		$name 		The name of the state to get
- * @return 	map 				A state map object
- */
+////
+//  Get a state map
+//
+// @param 	string 		$name 		The name of the state to get
+// @return 	map 				A state map object
+////
 @function _gridle_get_state(
 	$stateMap-or-stateName
 ) {
@@ -103,12 +103,12 @@
 }
 
 
-/**
- * Check if a state exist :
- *
- * @param 	string 		$name 		The name of the state to check
- * @return 	Boolean 			true is exist
- */
+////
+// Check if a state exist :
+//
+// @param 	string 		$name 		The name of the state to check
+// @return 	Boolean 			true is exist
+////
 @function _gridle_has_state(
 	$stateName
 ) {
@@ -120,13 +120,13 @@
 }
 
 
-/**
- * Get the media queries variables :
- *
- * @param 	int 		$index 	 	The media query indes
- * @param 	String 		$var 		The media query variable name
- * @return 	String|int 			The variable value
- */
+////
+// Get the media queries variables :
+//
+// @param 	int 		$index 	 	The media query indes
+// @param 	String 		$var 		The media query variable name
+// @return 	String|int 			The variable value
+////
 @function _gridle_get_state_var(
 	$stateName,
 	$var 	: "name"
@@ -147,13 +147,13 @@
 }
 
 
-/**
- * Get a variable
- *
- * @param 	String 		$varName 				The variable name
- * @param  	String 		$stateMap-or-stateName 	 	The state name or a map state value
- * @return 	Mixed 							The finded value
- */
+////
+// Get a variable
+//
+// @param 	String 		$varName 				The variable name
+// @param  	String 		$stateMap-or-stateName 	 	The state name or a map state value
+// @return 	Mixed 							The finded value
+////
 @function _gridle_get_var_value(
 	$varName,
 	$stateMap-or-stateName : null
@@ -176,13 +176,13 @@
 }
 
 
-/**
- * Set a variable in a state
- * @param 	Mixed $stateName-or-stateIndex 	The state name of state index
- * @param  	String $var                    		Variable name to assign
- * @param  	Mixed $newValue          		The new value to assign
- * @return 	List                         			The states list (full)
- */
+////
+// Set a variable in a state
+// @param 	Mixed $stateName-or-stateIndex 	The state name of state index
+// @param  	String $var                    		Variable name to assign
+// @param  	Mixed $newValue          		The new value to assign
+// @return 	List                         			The states list (full)
+////
 @function _gridle_set_state_var(
 	$stateName,
 	$var,
@@ -210,14 +210,14 @@
 }
 
 
-/**
- * Generate a column
- *
- * @param 	String 		$name 			The column name (often count)
- * @param 	int 		$columns 		The column count that the column will take
- * @param 	int 		$context 		The context on witch the with will be calculed
- * @param 	Boolean 	$generateClasses 	Set if the column has to be generated in css
- */
+////
+// Generate a column
+//
+// @param 	String 		$name 			The column name (often count)
+// @param 	int 		$columns 		The column count that the column will take
+// @param 	int 		$context 		The context on witch the with will be calculed
+// @param 	Boolean 	$generateClasses 	Set if the column has to be generated in css
+////
 @function _gridle_create_column(
 	$name,
 	$columns,
@@ -233,13 +233,13 @@
 }
 
 
-/**
- * Generate classname
- *
- * @param 	List 		$parrern 	The pattern to use to generate classname
- * @param 	String 		$state 		The state
- * @param 	int 		$count 		The column count
- */
+////
+// Generate classname
+//
+// @param 	List 		$parrern 	The pattern to use to generate classname
+// @param 	String 		$state 		The state
+// @param 	int 		$count 		The column count
+////
 @function _gridle_classname(
 	$pattern,
 	$state : null,
@@ -313,13 +313,13 @@
 }
 
 
-/**
- * Get the media query for a particular state, or with, etc...
- *
- * @param 	Mixed 		$state-or-min-width 		The state name of the min with
- * @param 	Mixed 		$max-width 			The max width if first param is a min width
- * @return 	String 						The media query string without the @media
- */
+////
+// Get the media query for a particular state, or with, etc...
+//
+// @param 	Mixed 		$state-or-min-width 		The state name of the min with
+// @param 	Mixed 		$max-width 			The max width if first param is a min width
+// @return 	String 						The media query string without the @media
+////
 @function _gridle_get_media_query(
 	$state-or-settings
 ) {
@@ -377,11 +377,11 @@
 }
 
 
-/**
- * Get states count
- * 
- * @return 	int 	The number of states defined
- */
+////
+// Get states count
+// 
+// @return 	int 	The number of states defined
+////
 @function _gridle_get_states_count() {
 	@return length($_gridle_states) / length($_gridle_states_vars_pattern);
 }

--- a/sass/gridle/_generate-mixins.scss
+++ b/sass/gridle/_generate-mixins.scss
@@ -5,12 +5,12 @@
 // |------------------------------------------------------
 
 
-/**
- * Generate a custom class for all the states
- *
- * @param 	list 	$pattern 		The name pattern of the class
- * @param 	list 	$statesNames 		The states names to generate
- */
+////
+// Generate a custom class for all the states
+//
+// @param 	list 	$pattern 		The name pattern of the class
+// @param 	list 	$statesNames 		The states names to generate
+////
 @mixin gridle_generate_custom_class(
 	$pattern,
 	$statesNames : null

--- a/sass/style.scss
+++ b/sass/style.scss
@@ -1,17 +1,11 @@
-/**
- * Imports :
- */
+// Imports :
 @import 'compass/reset';
 
-/**
- * Import grid settings :
- * This to be able to use gridle mixins, etc...
- */
+// Import grid settings :
+// This to be able to use gridle mixins, etc...
 @import 'grid-settings';
 
-/**
- * Medias :
- */
+// Medias :
 ul#medias {
 	background:black;
 	text-align:center;
@@ -41,9 +35,7 @@ ul#medias {
 	}
 }
 
-/**
- * Basic formatting :
- */
+// Basic formatting :
 html {
 	font:11px/1.5 'Helvetica Neue', Verdana, sans-serif;
 }
@@ -57,10 +49,7 @@ body {
 	}
 }
 
-
-/**
- * Gridle set sample :
- */
+// Gridle set sample :
 #myCoolItem {
 	@include gridle_set((
 		grid : 8,


### PR DESCRIPTION
Since ``/**`` and  ``/*`` style comments are preserved in the CSS output, I updated comments of these types to be ``//`` style comments instead.

**I tried to (mostly) use these conventions:**
``/** => ////``
``/* => //``
``* => //``