### PR TITLE
Classes that should be generated once are generated multiple times

### DIFF
--- a/sass/gridle/_generate-mixins.scss
+++ b/sass/gridle/_generate-mixins.scss
@@ -452,7 +452,7 @@
 		@include _gridle_generate_classes($states, $package, false);
 	}
 }
-$_gridle_generateOnlyOnce : true; // keep track of generate once classes
+$_gridle_generateOnlyOnce : true !default; // keep track of generate once classes
 @mixin _gridle_generate_classes(
 	$states : all,
 	$package : all,
@@ -498,7 +498,7 @@ $_gridle_generateOnlyOnce : true; // keep track of generate once classes
 	{
 
 		// update status
-		$_gridle_generateOnlyOnce : false;
+		$_gridle_generateOnlyOnce : false !global;
 
 		// | ------------------------
 		// | Windows 8 fix


### PR DESCRIPTION
The mixin `_gridle_generate_classes` uses a variable to check if some classes are already generated as they should only be generated once.
This variable is overwritten in the mixin but not passed to the global context. That means it gets the global context value every time the mixin is called.
The variable must be set with a  `!global` suffix